### PR TITLE
Library updates, make ssh keys and git config available in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,18 @@
     "workspaceFolder": "/app",
     // set the remote user to connect as
     "remoteUser": "app",
+    // mount ssh folder and git config to be able to use ssh keys for commit signing
+    // see https://dev.wiki.regiohelden.de/git/ for more details
+    // make sure to use relative paths to the home directory in your configs!
+    "mounts": [
+        "source=${localEnv:HOME}/.ssh,target=/home/app/.ssh,type=bind,readonly",
+        "source=${localEnv:HOME}/.config/git,target=/home/app/.config/git,type=bind,readonly"
+    ],
+    // initialize command to create the mount points for ssh and git config
+    // if they don't exist to prevent mount errors
+    "initializeCommand": {
+        "mkdir-mount": "mkdir -p /home/app/.ssh /home/app/.config/git || true"
+    },
     // features to be installed in the dev container
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2.5.9": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -172,7 +172,7 @@
                 "aaron-bond.better-comments",
                 // Linting with ruff
                 // https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff
-                "charliermarsh.ruff@2026.56.0",
+                "charliermarsh.ruff@2026.68.0",
                 // ---------------------------------------
                 // GIT
                 // ---------------------------------------

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
         "ghcr.io/devcontainers/features/common-utils:2.5.9": {},
         "ghcr.io/devcontainers/features/git:1.3.7": {},
         "ghcr.io/devcontainers-extra/features/ruff:2.0.0": {
-            "version": "0.15.20"
+            "version": "0.16.1"
         },
         "ghcr.io/devcontainers-extra/features/ty:1.0.0": {
             "version": "0.0.56"
@@ -157,7 +157,7 @@
                 "ms-python.python",
                 // ty - A fast Python language server and linter written in Rust
                 // https://marketplace.visualstudio.com/items?itemName=astral-sh.ty
-                "astral-sh.ty@2026.60.0",
+                "astral-sh.ty@2026.64.0",
                 // Python docstring generator
                 // https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring
                 "njpwerner.autodocstring",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,12 +21,12 @@
     // features to be installed in the dev container
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2.5.9": {},
-        "ghcr.io/devcontainers/features/git:1.3.7": {},
+        "ghcr.io/devcontainers/features/git:1.3.8": {},
         "ghcr.io/devcontainers-extra/features/ruff:2.0.0": {
             "version": "0.16.1"
         },
         "ghcr.io/devcontainers-extra/features/ty:1.0.0": {
-            "version": "0.0.56"
+            "version": "0.0.65"
         }
     },
     // configure vscode

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -34,12 +34,12 @@ jobs:
       - build-and-release
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.12"
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v8.3.0
+        uses: astral-sh/setup-uv@v9.0.0
 
       - name: Download the distribution packages
         uses: actions/download-artifact@v8.0.1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,4 +18,4 @@ jobs:
       contents: read
     uses: RegioHelden/github-reusable-workflows/.github/workflows/python-ruff.yaml@v2.9.0
     with:
-      ruff-version: "0.15.20"
+      ruff-version: "0.16.1"

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,12 @@ htmlcov
 .bash_history
 compose.override.yaml
 
+# vscode
+.vscode/*
+!.vscode/launch.json
+!.vscode/tasks.json
+.devcontainer/devcontainer-lock.json
+
 # Language specific
 __pycache__
 *.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=x LC_ALL=C.UTF-8 UV_COMPILE_BYTEC
 
 COPY system_dependencies.txt /app/
 
-RUN sys_deps=$(grep -v '^#' system_dependencies.txt | tr '\n' ' '); \
+RUN sys_deps=$(grep -v '^#' /app/system_dependencies.txt | tr '\n' ' '); \
     apt -y update && \
     apt -y --no-install-recommends install pipx $sys_deps && \
     apt clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,16 @@ FROM python:3.12-bookworm
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=x LC_ALL=C.UTF-8 UV_COMPILE_BYTECODE=0
 
+WORKDIR /app
+
 COPY system_dependencies.txt /app/
 
-RUN sys_deps=$(grep -v '^#' /app/system_dependencies.txt | tr '\n' ' '); \
+RUN sys_deps=$(grep -v '^#' system_dependencies.txt | tr '\n' ' '); \
     apt -y update && \
     apt -y --no-install-recommends install pipx $sys_deps && \
     apt clean && \
     find /usr/share/man /usr/share/locale /usr/share/doc -type f -delete && \
     rm -rf /var/lib/apt/lists/*
-
-WORKDIR /app
 
 RUN grep -q -w 1000 /etc/group || groupadd --gid 1000 app && \
     id -u app >/dev/null 2>&1 || useradd --gid 1000 --uid 1000 -m app && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY --chown=app requirements* /app/
 
 ENV PATH=/home/app/.local/bin:/home/app/venv/bin:${PATH} DJANGO_SETTINGS_MODULE=example.settings
 
-RUN pipx install --force uv==0.11.26 && \
+RUN pipx install --force uv==0.12.1 && \
     uv venv ~/venv --clear && \
     uv pip install --no-cache --upgrade --requirements /app/requirements-test.txt && \
     uv cache clean

--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ Activities and workflows should be declared in modules matching the following pa
 from temporalio import activity, workflow
 from django_temporalio.registry import queue_activities, queue_workflows
 
+
 @queue_activities.register("HIGH_PRIORITY_TASK_QUEUE", "MAIN_TASK_QUEUE")
 @activity.defn
 def my_activity():
     pass
+
 
 @queue_workflows.register("HIGH_PRIORITY_TASK_QUEUE", "MAIN_TASK_QUEUE")
 @workflow.defn


### PR DESCRIPTION
Update from RegioHelden's modulesync-config-django

- VSCode feature git to 1.3.8
- ruff to 0.16.1
- ruff VSCode extension to 2026.68.0
- ty to 0.0.65
- ty VSCode extension to 2026.64.0
- actions/setup-python to 7.0.0
- astral-sh/setup-uv to 9.0.0
- uv to 0.12.1