### PR TITLE
feat: add command to validate temporal workers

### DIFF
--- a/django_temporalio/management/commands/validate_temporalio_workers.py
+++ b/django_temporalio/management/commands/validate_temporalio_workers.py
@@ -1,0 +1,23 @@
+from asgiref.sync import async_to_sync
+from django.core.management import BaseCommand
+from temporalio.worker import Worker
+
+from django_temporalio.client import init_client
+from django_temporalio.registry import get_queue_registry
+
+
+class Command(BaseCommand):
+    help = "Validates Temporal.io workers."
+
+    @async_to_sync
+    async def handle(self, **kwargs):
+        self.stdout.write("👷 Validating workers...")
+        client = await init_client()
+        for queue_name, item in get_queue_registry().items():
+            Worker(
+                client,
+                task_queue=queue_name,
+                workflows=item.workflows,
+                activities=item.activities,
+            )
+        self.stdout.write(self.style.SUCCESS("🥳 All workers validated!"))


### PR DESCRIPTION
Adds the following command:

```sh
./manage.py validate_temporalio_workers
```

Can be used e.g. in CI to ensure workers will be able to start.

Detects, among others, problematic imports not properly guarded with `workflow.unsafe.imports_passed_through`.