### PR TITLE
Drop support for Django 4.2, use Python 3.13 on devcontainer and tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -71,7 +71,7 @@
                 // python environment
                 "python.defaultInterpreterPath": "/home/app/venv/bin/python",
                 "python.analysis.extraPaths": [
-                    "/home/app/venv/lib/python3.12/site-packages/"
+                    "/home/app/venv/lib/python3.13/site-packages/"
                 ],
                 "python.analysis.useImportHeuristic": true,
                 "python.analysis.autoSearchPaths": true,

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
     uses: RegioHelden/github-reusable-workflows/.github/workflows/build-and-publish.yaml@v2.9.0
     with:
-      python-version: "3.12"
+      python-version: "3.13"
 
   # must be defined in the repo as trusted publishing does not work with reusable workflows yet
   # see https://github.com/pypi/warehouse/issues/11096
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v10.0.1

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -19,6 +19,6 @@ jobs:
       contents: write
     uses: RegioHelden/github-reusable-workflows/.github/workflows/tag-release.yaml@v2.9.0
     with:
-      python-version: "3.12"
+      python-version: "3.13"
     secrets:
       personal-access-token: "${{ secrets.COMMIT_KEY }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Managed by modulesync - DO NOT EDIT
 # -------------------------------------------------
 
-FROM python:3.12-bookworm
+FROM python:3.13-bookworm
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=x LC_ALL=C.UTF-8 UV_COMPILE_BYTECODE=0

--- a/django_temporalio/tests/management_commands/test_start_temporalio_worker.py
+++ b/django_temporalio/tests/management_commands/test_start_temporalio_worker.py
@@ -180,7 +180,7 @@ class StartTemporalioWorkerTestCase(TestCase):
         # use regex due to different error messages in different Python versions
         self.assertRegex(
             str(cm.exception),
-            r"Error: argument worker_name: invalid choice: '?worker_3'? ",
+            r"Error: argument worker_name: invalid choice: '?worker_3'?",
         )
         self.assertRegex(
             str(cm.exception),

--- a/django_temporalio/tests/management_commands/test_start_temporalio_worker.py
+++ b/django_temporalio/tests/management_commands/test_start_temporalio_worker.py
@@ -180,7 +180,10 @@ class StartTemporalioWorkerTestCase(TestCase):
         # use regex due to different error messages in different Python versions
         self.assertRegex(
             str(cm.exception),
-            r"Error: argument worker_name: invalid choice: '?worker_3'? "
+            r"Error: argument worker_name: invalid choice: '?worker_3'? ",
+        )
+        self.assertRegex(
+            str(cm.exception),
             r"\(choose from '?worker_1'?, '?worker_2'?\)",
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = ["django>=4.2,<6.1", "temporalio>=1.18.0"]
+dependencies = ["django>=5.2,<6.2", "temporalio>=1.18.0"]
 
 [project.urls]
 Homepage = "https://github.com/RegioHelden/django-temporalio"


### PR DESCRIPTION
Update from RegioHelden's modulesync-config-django